### PR TITLE
chore: bump DRF from 3.8.2 to 3.9.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django==2.1.7
 python-dotenv==0.8.2
-djangorestframework==3.8.2
+djangorestframework==3.9.4
 django_extensions==2.1.2
 git-pylint-commit-hook==2.5.1
 pylint_django==2.0.4


### PR DESCRIPTION
Resolves `djangorestframework` [security alert](/iamogbz/demo-toptal/network/alert/requirements.txt/djangorestframework/open)

Closes #2 